### PR TITLE
fix upload file with nested path

### DIFF
--- a/src/Storage.Tests/ObjectShould.cs
+++ b/src/Storage.Tests/ObjectShould.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using static Storage.Tests.StorageFixture;
 
 namespace Storage.Tests;
@@ -506,6 +506,25 @@ public sealed class ObjectShould : IClassFixture<StorageFixture>
 			.Invoking(client => client.UploadFile(fileName, StreamContentType, fileArray, _ct))
 			.Should().ThrowAsync<HttpRequestException>();
 	}
+
+	[Theory]
+	[InlineData("some/foo/audio.wav", 1024)]
+	[InlineData("another/path/test.mp3", 2048)]
+	public async Task UploadFileWithNestedPath(string nestedFileName, int dataSize)
+	{
+		var data = GetByteArray(dataSize); // Пример данных, которые вы хотите загрузить
+
+		// Act
+		var result = await _client.UploadFile(nestedFileName, StreamContentType, data, _ct);
+		Assert.True(result);
+
+		// Assert
+		var exists = await _client.IsFileExists(nestedFileName, _ct);
+		Assert.True(exists, "The object should exist in the S3 bucket");
+
+		await DeleteTestFile(nestedFileName);
+	}
+
 
 	[Fact]
 	public async Task ThrowIfUploadDisposed()

--- a/src/Storage/Utils/HttpDescription.cs
+++ b/src/Storage/Utils/HttpDescription.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Collections.Frozen;
 using System.Text;
 
@@ -7,7 +7,7 @@ namespace Storage.Utils;
 internal readonly struct HttpDescription
 {
 	private static readonly FrozenSet<char> _validUrlCharacters =
-		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~".ToFrozenSet();
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~/".ToFrozenSet();
 
 	private readonly string _headerEnd;
 	private readonly string _headerStart;

--- a/src/Storage/Utils/ValueStringBuilder.cs
+++ b/src/Storage/Utils/ValueStringBuilder.cs
@@ -1,11 +1,11 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Globalization;
 
 namespace Storage.Utils;
 
-internal ref struct ValueStringBuilder(Span<char> buffer)
+internal ref struct ValueStringBuilder(Span<char> initialBuffer)
 {
-	private Span<char> _buffer = buffer;
+	private Span<char> _buffer = initialBuffer;
 	private int _length = 0;
 	private char[]? _array = null;
 


### PR DESCRIPTION
Мелкий фикс для работы с вложенными путями

```csharp
	[Theory]
	[InlineData("some/foo/audio.wav", 1024)]
	[InlineData("another/path/test.mp3", 2048)]
	public async Task UploadFileWithNestedPath(string nestedFileName, int dataSize)
	{
		var data = GetByteArray(dataSize); 
		// Act
		var result = await _client.UploadFile(nestedFileName, StreamContentType, data, _ct);
		Assert.True(result);

		// Assert
		var exists = await _client.IsFileExists(nestedFileName, _ct);
		Assert.True(exists, "The object should exist in the S3 bucket");

		await DeleteTestFile(nestedFileName);
	}
```